### PR TITLE
fix compilation errors on modern g++/c++ compiler (Ubuntu 20)

### DIFF
--- a/include/spdlog/details/format.cc
+++ b/include/spdlog/details/format.cc
@@ -480,23 +480,23 @@ public:
         typedef typename BasicWriter<Char>::CharPtr CharPtr;
         Char fill = internal::CharTraits<Char>::cast(spec_.fill());
         CharPtr out = CharPtr();
-        const unsigned CHAR_WIDTH = 1;
-        if (spec_.width_ > CHAR_WIDTH) {
+        const unsigned CHAR_SIZE = 1;
+        if (spec_.width_ > CHAR_SIZE) {
             out = writer_.grow_buffer(spec_.width_);
             if (spec_.align_ == ALIGN_RIGHT) {
-                std::fill_n(out, spec_.width_ - CHAR_WIDTH, fill);
-                out += spec_.width_ - CHAR_WIDTH;
+                std::fill_n(out, spec_.width_ - CHAR_SIZE, fill);
+                out += spec_.width_ - CHAR_SIZE;
             }
             else if (spec_.align_ == ALIGN_CENTER) {
                 out = writer_.fill_padding(out, spec_.width_,
-                                           internal::check(CHAR_WIDTH), fill);
+                                           internal::check(CHAR_SIZE), fill);
             }
             else {
-                std::fill_n(out + CHAR_WIDTH, spec_.width_ - CHAR_WIDTH, fill);
+                std::fill_n(out + CHAR_SIZE, spec_.width_ - CHAR_SIZE, fill);
             }
         }
         else {
-            out = writer_.grow_buffer(CHAR_WIDTH);
+            out = writer_.grow_buffer(CHAR_SIZE);
         }
         *out = internal::CharTraits<Char>::cast(value);
     }

--- a/include/spdlog/spdlog.h
+++ b/include/spdlog/spdlog.h
@@ -11,6 +11,7 @@
 #include "tweakme.h"
 #include "common.h"
 #include "logger.h"
+#include <functional>
 
 namespace spdlog
 {

--- a/src/relatedness.cpp
+++ b/src/relatedness.cpp
@@ -117,7 +117,7 @@ void relatedness::populate_data_new() {
 
         // For each sample in this variant
         for (auto s = var.samples.begin(); s != var.samples.end(); ++s) {
-
+            
             auto& sample = s->second;
 
             // Get the genotype
@@ -131,7 +131,7 @@ void relatedness::populate_data_new() {
 
             if (l == sample.end()) {
                 logger->error("Couldn't find the required field {} in record {}",
-                              genotypeFieldName, s->first);
+                            genotypeFieldName, s->first);
                 std::exit(1);
             }
 
@@ -152,13 +152,13 @@ void relatedness::populate_data_new() {
             // If one or both of the genotypes are null ".", then
             // fill in the likelihoods as invalid and move on to the
             // next sample for this variant.
-            if (gtstr != "./." and gtstr != ".|.") {
+            if (gtstr != "./." and gtstr != ".|." and gtstr != ".") {
                 auto gtVec = split(gtstr, "/|");
                 // Check that there are only 2 alleles?
                 if (gtVec[0] == "." or gtVec[1] == ".") {
                     gls = {-std::numeric_limits<double>::infinity(),
-                           -std::numeric_limits<double>::infinity(),
-                           -std::numeric_limits<double>::infinity()};
+                        -std::numeric_limits<double>::infinity(),
+                        -std::numeric_limits<double>::infinity()};
                     parseLikelihoods = false;
                 }
                 int ga = std::stoi(gtVec[0]);
@@ -168,8 +168,8 @@ void relatedness::populate_data_new() {
                 totGT += 2;
             } else {
                 gls = {-std::numeric_limits<double>::infinity(),
-                       -std::numeric_limits<double>::infinity(),
-                       -std::numeric_limits<double>::infinity()};
+                    -std::numeric_limits<double>::infinity(),
+                    -std::numeric_limits<double>::infinity()};
                 parseLikelihoods = false;
             }
 
@@ -219,7 +219,7 @@ void relatedness::populate_data_new() {
                 }
             }
             variantLikelihoods[sampleIndex] = gls;
-        }
+        } 
         genotypeLikelihoods.push_back(std::move(variantLikelihoods));
 
         if (totGT == 0) {


### PR DESCRIPTION
These changes fix the compilation errors that occur on running make (e.g. #19)  using new compilers such as those found on Ubuntu 20.

I successfully compiled with:
`g++ (Ubuntu 9.3.0-17ubuntu1~20.04) 9.3.0.`

I also tried to compile with `clang version 10.0.0-4ubuntu1` but this gave me a linker error.

At least with g++/c++ users should be able to get lcmlkin to compile.
